### PR TITLE
Calc extinction

### DIFF
--- a/lightcurve_fitting/filters.py
+++ b/lightcurve_fitting/filters.py
@@ -230,8 +230,8 @@ class Filter:
             self.freq_eff = freq_eff
             self.dfreq = -dfreq
             self.freq_range = (freq_eff.value - freq0, freq1 - freq_eff.value)
-
-            self.R = fitzpatrick99(np.array([self.wl_eff.to(u.angstrom).value]), 1.)[0]
+            # if Av=3.1 and Rv=3.1 then E(B-V)=1 --> A_eff=R_eff
+            self.R = fitzpatrick99(np.array([self.wl_eff.to(u.angstrom).value]), 3.1)[0]
 
     def synthesize(self, spectrum, *args, z=0., ebv=0., **kwargs):
         """

--- a/lightcurve_fitting/filters.py
+++ b/lightcurve_fitting/filters.py
@@ -230,8 +230,6 @@ class Filter:
             self.freq_eff = freq_eff
             self.dfreq = -dfreq
             self.freq_range = (freq_eff.value - freq0, freq1 - freq_eff.value)
-            # if Av=3.1 and Rv=3.1 then E(B-V)=1 --> A_eff=R_eff
-            self.R = fitzpatrick99(np.array([self.wl_eff.to(u.angstrom).value]), 3.1)[0]
 
     def synthesize(self, spectrum, *args, z=0., ebv=0., **kwargs):
         """

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -4,6 +4,7 @@ from matplotlib.path import Path
 from astropy.table import Table, vstack, MaskedColumn
 from .filters import filtdict
 import itertools
+from extinction import fitzpatrick99
 from matplotlib.markers import MarkerStyle
 try:
     from config import markers
@@ -309,16 +310,16 @@ class LC(Table):
         elif self.sn is not None:
             self.meta['extinction'] = self.sn.extinction
         elif 'extinction' not in self.meta:
-            self.meta['extinction'] = {f.name: ebv * rv / 3.1 * f.R for f in set(self['filter'])
-                                       if f.R is not None and ebv is not None}
+            self.meta['extinction'] = {f.name: fitzpatrick99(np.array([f.wl_eff.to(u.angstrom).value]), rv*ebv, rv)[0] for f in set(self['filter'])
+                                       if f.wl_eff is not None and ebv is not None}
 
         if hostext is not None:
             self.meta['hostext'] = hostext
         elif self.sn is not None:
             self.meta['hostext'] = self.sn.hostext
         elif 'hostext' not in self.meta:
-            self.meta['hostext'] = {f.name: host_ebv * host_rv / 3.1 * f.R for f in set(self['filter'])
-                                    if f.R is not None and host_ebv is not None}
+            self.meta['hostext'] = {f.name: fitzpatrick99(np.array([f.wl_eff.to(u.angstrom).value]), host_rv*host_ebv, host_rv)[0] for f in set(self['filter'])
+                                       if f.wl_eff is not None and host_ebv is not None}
 
         self['absmag'] = self['mag'].data - self.meta['dm']
         for filtobj in set(self['filter']):


### PR DESCRIPTION
This is a slightly different implementation than @griffin-h started but I think it is more straightforward. Semi tested using SN 2022jox

Manual calculations yield:
lc.meta['extinction'] = {
 'UVW2': 0.667,
 'UVM2': 0.754,
 'UVW1': 0.542,
 'us': 0.406,
 'bs': 0.334,
 'vs': 0.251,
 'U': 0.404,
 'B': 0.338,
 'g': 0.208,
 'V': 0.255,
 'DLT40': 0.213,
 'r': 0.213,
 'i': 0.158,
}

for central wavelengths listed in NED
DM = 32.88
E(B-V) = 0.0822


