### PR TITLE
adding from_table function

### DIFF
--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -546,7 +546,7 @@ class LC(Table):
             fill_values = [('--', '0'), ('', '0')]
         t.fill_values = fill_values
         t = t.filled()
-        t = super(LC,cls)(t)
+        t = LC(t)
         t.normalize_column_names()
         if 'filt' in t.colnames:
             t.filters_to_objects()

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -540,6 +540,16 @@ class LC(Table):
             t.filters_to_objects()
         return t
 
+    @classmethod
+    def from_table(cls, t, fill_values=None):
+        if fill_values is None:
+            fill_values = [('--', '0'), ('', '0')]
+        t = t.filled(fill_values)
+        t.normalize_column_names()
+        if 'filt' in t.colnames:
+            t.filters_to_objects()
+        return t
+
 
 def flux2mag(flux, dflux=np.array(np.nan), zp=0., nondet=None, nondetSigmas=3.):
     """

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -544,7 +544,8 @@ class LC(Table):
     def from_table(cls, t, fill_values=None):
         if fill_values is None:
             fill_values = [('--', '0'), ('', '0')]
-        t = t.filled(fill_values)
+        t.fill_values = fill_values
+        t = t.filled()
         t.normalize_column_names()
         if 'filt' in t.colnames:
             t.filters_to_objects()

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -546,6 +546,7 @@ class LC(Table):
             fill_values = [('--', '0'), ('', '0')]
         t.fill_values = fill_values
         t = t.filled()
+        t = super(LC,cls)(t)
         t.normalize_column_names()
         if 'filt' in t.colnames:
             t.filters_to_objects()

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -545,7 +545,6 @@ class LC(Table):
         if fill_values is None:
             fill_values = [('--', '0'), ('', '0')]
         t.fill_values = fill_values
-        t = t.filled()
         t = LC(t)
         t.normalize_column_names()
         if 'filt' in t.colnames:


### PR DESCRIPTION
the `lightcurve.LC` class can currently be initialized from a table, but to really use the rest of the package you need to normalize the column names and create the filter column with filter objects. This functionality is implemented in the `read` function but there are times when one doesn't want to have to write out ones data (e.g. when retrieving from a database). This PR implements a `from_table` class method which initialized a `LC` object in the same way the `read` function does but from an astropy table rather than a file.