### PR TITLE
avoid crash in scale_sifto without DLT40 data

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+Unreleased
+----------
+* Fix ``KeyError`` when using :class:`.CompanionShocking` models without DLT40 photometry
+
 v0.9.0 (2023-06-16)
 -------------------
 * Add :class:`.ShockCooling4` model from [MSW23]_

--- a/lightcurve_fitting/models.py
+++ b/lightcurve_fitting/models.py
@@ -699,19 +699,21 @@ class BaseCompanionShocking(Model):
             lc.calcLum()
 
         self.sifto = {}
-        dlt40 = filtdict['DLT40']
-        unfilt = filtdict['unfilt.']
         for filt in set(lc['filter']):
-            if filt.char in sifto.colnames or filt == dlt40:
-                char = 'r' if filt == dlt40 else filt.char
-                lc_filt = lc.where(filter=filt)
-                sifto_scaled = sifto[char] * np.max(lc_filt['lum']) / np.max(sifto[char])
-                self.sifto[filt] = CubicSpline(sifto['Epoch'], sifto_scaled, extrapolate=False)
-            elif filt != unfilt:
+            if filt.name == 'unfilt.':  # assume unfiltered = DLT40 for now
+                sifto_filt = 'r'
+                scale_filt = 'DLT40'
+            elif filt.name == 'DLT40':
+                sifto_filt = 'r'
+                scale_filt = filt
+            elif filt.char in sifto.colnames:
+                sifto_filt = filt.char
+                scale_filt = filt
+            else:
                 raise Exception('No SiFTO template for filter ' + filt.name)
-
-        # assume unfiltered = DLT40 for now
-        self.sifto[unfilt] = self.sifto[dlt40]
+            lc_filt = lc.where(filter=scale_filt)
+            sifto_scaled = sifto[sifto_filt] * np.max(lc_filt['lum']) / np.max(sifto[sifto_filt])
+            self.sifto[filt] = CubicSpline(sifto['Epoch'], sifto_scaled, extrapolate=False)
 
     def __repr__(self):
         return f'<{self.__class__.__name__}: z={self.z:.3f}>'

--- a/lightcurve_fitting/models.py
+++ b/lightcurve_fitting/models.py
@@ -700,7 +700,8 @@ class BaseCompanionShocking(Model):
 
         self.sifto = {}
         for filt in set(lc['filter']):
-            if filt.name == 'unfilt.':  # assume unfiltered = DLT40 for now
+            # only use unfiltered data if DLT40 data are also present, and assume they have the same peak luminosity
+            if filt.name == 'unfilt.' and filtdict['DLT40'] in lc['filter']:
                 sifto_filt = 'r'
                 scale_filt = 'DLT40'
             elif filt.name == 'DLT40':


### PR DESCRIPTION
Resolves #8 by rejecting unfiltered data for the Companion Shocking models unless DLT40 clear data are also present. We assume that both of these bands look like the SiFTO r band, but we only scale to the peak luminosity of the DLT40 data, in case the peak is not observed in the unfiltered data.