### PR TITLE
Add warning when refmjd is set automatically and add to documentation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -58,7 +58,7 @@ as well as a method for plotting the light curve in a single command:
     lc.plot()
 
 In the above example, the phase will be calculated based on the first detection. Alternately, the zero point of the phase can be set by adding the `refmjd` key set equal to the desired zero point in the the :attr:`LC.meta` attribute.
-Alternately, the brightest point can be used for the phase zero point by first running the :meth:`lightcurve.LC.findPeak` method and then :meth:`lightcurve.LC.calcPhase` with `rspd=True`
+Alternately, the brightest point can be used for the phase zero point by first running the :meth:`lightcurve.LC.findPeak` method and then :meth:`lightcurve.LC.calcPhase` with `rdsp=True`
 
 Filters
 -------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -48,6 +48,12 @@ The :attr:`LC.meta` attribute contains information needed to calculate absolute 
     lc.meta['host_ebv'] = 0.
     lc.meta['redshift'] = 0.002
 
+In the above example, the phase will be calculated based on the first detection. Alternately, the phase can be 
+calculated from an explosion or peak time by populating the :attr:`LC.meta` attribute with the following keys:
+* refmjd: the reference time in MJD
+* explosion: the explosion time in MJD
+* peaktime: the time of the light curve max in MJD. This can be populated manually or using :meth:`lightcurve.LC.findPeak` method
+
 The :class:`.LC` object has several methods for converting between the columns above,
 as well as a method for plotting the light curve in a single command:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -48,12 +48,6 @@ The :attr:`LC.meta` attribute contains information needed to calculate absolute 
     lc.meta['host_ebv'] = 0.
     lc.meta['redshift'] = 0.002
 
-In the above example, the phase will be calculated based on the first detection. Alternately, the phase can be 
-calculated from an explosion or peak time by populating the :attr:`LC.meta` attribute with the following keys:
-* refmjd: the reference time in MJD
-* explosion: the explosion time in MJD
-* peaktime: the time of the light curve max in MJD. This can be populated manually or using :meth:`lightcurve.LC.findPeak` method
-
 The :class:`.LC` object has several methods for converting between the columns above,
 as well as a method for plotting the light curve in a single command:
 
@@ -62,6 +56,9 @@ as well as a method for plotting the light curve in a single command:
     lc.calcAbsMag()
     lc.calcPhase()
     lc.plot()
+
+In the above example, the phase will be calculated based on the first detection. Alternately, the zero point of the phase can be set by adding the `refmjd` key set equal to the desired zero point in the the :attr:`LC.meta` attribute.
+Alternately, the brightest point can be used for the phase zero point by first running the :meth:`lightcurve.LC.findPeak` method and then :meth:`lightcurve.LC.calcPhase` with `rspd=True`
 
 Filters
 -------

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -427,6 +427,7 @@ class LC(Table):
                 raise Exception('must run lc.findPeak() first')
             elif rdsp:
                 self.meta['refmjd'] = self.meta['peakdate']
+                warnings.warn('refmjd and explosion not in meta. Setting phase based on peakdate')
             elif self.meta.get('explosion') is not None:
                 self.meta['refmjd'] = self.meta['explosion']
             else:
@@ -435,6 +436,7 @@ class LC(Table):
                 else:
                     detections = self
                 self.meta['refmjd'] = np.min(detections['MJD'].data)
+                warnings.warn('refmjd and explosion not in meta. Setting phase based on first detection')
         self['phase'] = (self['MJD'].data - self.meta['refmjd']) / (1 + self.meta['redshift']) * u.day
         if 'dMJD' in self.colnames:
             self['dphase'] = self['dMJD'] / (1. + self.meta['redshift']) * u.day

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -436,7 +436,7 @@ class LC(Table):
                 else:
                     detections = self
                 self.meta['refmjd'] = np.min(detections['MJD'].data)
-                warnings.warn('refmjd not in meta. Setting phase to first detection')
+                warnings.warn('refmjd not in meta. Setting phase based on first detection')
         self['phase'] = (self['MJD'].data - self.meta['refmjd']) / (1 + self.meta['redshift']) * u.day
         if 'dMJD' in self.colnames:
             self['dphase'] = self['dMJD'] / (1. + self.meta['redshift']) * u.day

--- a/lightcurve_fitting/lightcurve.py
+++ b/lightcurve_fitting/lightcurve.py
@@ -427,7 +427,7 @@ class LC(Table):
                 raise Exception('must run lc.findPeak() first')
             elif rdsp:
                 self.meta['refmjd'] = self.meta['peakdate']
-                warnings.warn('refmjd and explosion not in meta. Setting phase based on peakdate')
+                warnings.warn('refmjd not in meta. Setting phase based on brightest detection')
             elif self.meta.get('explosion') is not None:
                 self.meta['refmjd'] = self.meta['explosion']
             else:
@@ -436,7 +436,7 @@ class LC(Table):
                 else:
                     detections = self
                 self.meta['refmjd'] = np.min(detections['MJD'].data)
-                warnings.warn('refmjd and explosion not in meta. Setting phase based on first detection')
+                warnings.warn('refmjd not in meta. Setting phase to first detection')
         self['phase'] = (self['MJD'].data - self.meta['refmjd']) / (1 + self.meta['redshift']) * u.day
         if 'dMJD' in self.colnames:
             self['dphase'] = self['dMJD'] / (1. + self.meta['redshift']) * u.day


### PR DESCRIPTION
I added a warning when refmjd is set either from `meta['peaktime']` or from the first detection.  I also added a note to the usage documentation about the different meta keywords that can be used to calculate phase (and the default behavior) because I couldn't find this spelled out anywhere in the docstrings.