### PR TITLE
Changes to support new python versions

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -9,6 +9,7 @@ Unreleased
 * Add the :meth:`.LC.calcFlam` method for convenience
 * Fix bug in parsing color columns in :func:`.plot_color_curves`
 * Adds support for Python 3.12
+* Adds support for Numpy 2
 * Give a warning when `'refmjd'` is set automatically
 * Correct typos in :class:`.ShockCooling4`:
 

--- a/lightcurve_fitting.ipynb
+++ b/lightcurve_fitting.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "from lightcurve_fitting import lightcurve, models, fitting, bolometric"
@@ -110,7 +112,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "fig, ax_corner, ax_model = fitting.lightcurve_corner(lc_early, model, sampler.flatchain)"
@@ -197,15 +201,8 @@
    "outputs": [],
    "source": [
     "fig1 = bolometric.plot_bolometric_results(t)\n",
-    "fig2 = bolometric.plot_color_curves(t, colors=['g-r', 'B-V', 'r-i'])"
+    "fig2 = bolometric.plot_color_curves(t)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -224,9 +221,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.4"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 1
 }

--- a/lightcurve_fitting.ipynb
+++ b/lightcurve_fitting.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from lightcurve_fitting import lightcurve, models, fitting, bolometric"
@@ -112,9 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax_corner, ax_model = fitting.lightcurve_corner(lc_early, model, sampler.flatchain)"
@@ -201,8 +197,15 @@
    "outputs": [],
    "source": [
     "fig1 = bolometric.plot_bolometric_results(t)\n",
-    "fig2 = bolometric.plot_color_curves(t)"
+    "fig2 = bolometric.plot_color_curves(t, colors=['g-r', 'B-V', 'r-i'])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -221,9 +224,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/lightcurve_fitting/bolometric.py
+++ b/lightcurve_fitting/bolometric.py
@@ -54,7 +54,7 @@ def pseudo(temp, radius, z, filter0=filtdict['I'], filter1=filtdict['U'], cutoff
     freq1 = (filter1.freq_eff + filter1.dfreq / 2.).value
     x_optical = np.arange(freq0, freq1)
     y_optical = planck_fast(x_optical * (1. + z), temp, radius, cutoff_freq)
-    L_opt = np.trapz(y_optical) * 1e12  # dx = 1 THz
+    L_opt = np.trapezoid(y_optical) * 1e12  # dx = 1 THz
     return L_opt
 
 
@@ -552,7 +552,7 @@ def integrate_sed(epoch1):
     lums = np.insert(epoch1['lum'], 0, 0)
     freqs = np.append(freqs, epoch1['freq'][-1] + epoch1['dfreq'][-1])
     lums = np.append(lums, 0)
-    L_int = np.trapz(lums * epoch1['lum'].unit, freqs * epoch1['freq'].unit).to(u.W).value
+    L_int = np.trapezoid(lums * epoch1['lum'].unit, freqs * epoch1['freq'].unit).to(u.W).value
     return L_int
 
 

--- a/lightcurve_fitting/bolometric.py
+++ b/lightcurve_fitting/bolometric.py
@@ -7,6 +7,10 @@ from astropy import constants as const
 from astropy import units as u
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
 import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit, OptimizeWarning
 from scipy.stats import gaussian_kde
@@ -54,7 +58,7 @@ def pseudo(temp, radius, z, filter0=filtdict['I'], filter1=filtdict['U'], cutoff
     freq1 = (filter1.freq_eff + filter1.dfreq / 2.).value
     x_optical = np.arange(freq0, freq1)
     y_optical = planck_fast(x_optical * (1. + z), temp, radius, cutoff_freq)
-    L_opt = np.trapezoid(y_optical) * 1e12  # dx = 1 THz
+    L_opt = trapezoid(y_optical) * 1e12  # dx = 1 THz
     return L_opt
 
 
@@ -552,7 +556,7 @@ def integrate_sed(epoch1):
     lums = np.insert(epoch1['lum'], 0, 0)
     freqs = np.append(freqs, epoch1['freq'][-1] + epoch1['dfreq'][-1])
     lums = np.append(lums, 0)
-    L_int = np.trapezoid(lums * epoch1['lum'].unit, freqs * epoch1['freq'].unit).to(u.W).value
+    L_int = trapezoid(lums * epoch1['lum'].unit, freqs * epoch1['freq'].unit).to(u.W).value
     return L_int
 
 

--- a/lightcurve_fitting/filters.py
+++ b/lightcurve_fitting/filters.py
@@ -1,4 +1,8 @@
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
 import matplotlib.pyplot as plt
 from astropy.table import Table
 import astropy.units as u
@@ -191,8 +195,8 @@ class Filter:
             trans['T'] /= np.max(trans['T'])
             trans['freq'] = (const.c / trans['wl']).to(u.THz)
 
-            dwl = np.trapezoid(trans['T'].quantity, trans['wl'].quantity)
-            wl_eff = np.trapezoid(trans['T'].quantity * trans['wl'].quantity, trans['wl'].quantity) / dwl
+            dwl = trapezoid(trans['T'].quantity, trans['wl'].quantity)
+            wl_eff = trapezoid(trans['T'].quantity * trans['wl'].quantity, trans['wl'].quantity) / dwl
             wl0_guess = trans[trans['T'] > 0.5]['wl'].min()
             left = trans[(trans['wl'] <= wl0_guess) & (trans['T'] >= 0.1)]
             wl0 = np.interp(0.5, left['T'], left['wl'])
@@ -208,13 +212,13 @@ class Filter:
                 ax1.set_xlabel('Wavelength (nm)')
                 ax1.set_ylabel('Transmission')
 
-            dfreq = np.trapezoid(trans['T'].quantity, trans['freq'].quantity)
-            freq_eff = np.trapezoid(trans['T'].quantity * trans['freq'].quantity,
+            dfreq = trapezoid(trans['T'].quantity, trans['freq'].quantity)
+            freq_eff = trapezoid(trans['T'].quantity * trans['freq'].quantity,
                                 trans['freq'].quantity) / dfreq
             freq0 = np.interp(0.5, right['T'], right['freq'])
             freq1 = np.interp(0.5, left['T'], left['freq'])
             T_per_freq = trans['T'].quantity / trans['freq'].quantity
-            trans['T_norm_per_freq'] = (T_per_freq / np.trapezoid(T_per_freq, trans['freq'].quantity))
+            trans['T_norm_per_freq'] = (T_per_freq / trapezoid(T_per_freq, trans['freq'].quantity))
             if show:
                 plt.figure(2)
                 ax2 = plt.gca()
@@ -309,7 +313,7 @@ class Filter:
             Average spectral luminosity in the filter in watts per hertz
         """
         freq = self.trans['freq'].value * (1. + z)
-        return np.trapezoid(spectrum(freq, *args, **kwargs) * extinction_law(freq, ebv)
+        return trapezoid(spectrum(freq, *args, **kwargs) * extinction_law(freq, ebv)
                         * self.trans['T_norm_per_freq'].data, self.trans['freq'].data)
 
     def spectrum(self, freq, lum, z=0., ebv=0.):
@@ -339,8 +343,8 @@ class Filter:
         freq *= (1. + z)
         T_per_freq = self.trans['T'].value / self.trans['freq'].value
         T_interp = np.interp(freq, self.trans['freq'][::-1].value, T_per_freq[::-1], left=0., right=0.)
-        T_norm_per_freq = T_interp / np.trapezoid(T_interp, freq)
-        return np.trapezoid(lum * extinction_law(freq, ebv) * T_norm_per_freq, freq)
+        T_norm_per_freq = T_interp / trapezoid(T_interp, freq)
+        return trapezoid(lum * extinction_law(freq, ebv) * T_norm_per_freq, freq)
 
     def __str__(self):
         return self.name

--- a/lightcurve_fitting/filters.py
+++ b/lightcurve_fitting/filters.py
@@ -191,8 +191,8 @@ class Filter:
             trans['T'] /= np.max(trans['T'])
             trans['freq'] = (const.c / trans['wl']).to(u.THz)
 
-            dwl = np.trapz(trans['T'].quantity, trans['wl'].quantity)
-            wl_eff = np.trapz(trans['T'].quantity * trans['wl'].quantity, trans['wl'].quantity) / dwl
+            dwl = np.trapezoid(trans['T'].quantity, trans['wl'].quantity)
+            wl_eff = np.trapezoid(trans['T'].quantity * trans['wl'].quantity, trans['wl'].quantity) / dwl
             wl0_guess = trans[trans['T'] > 0.5]['wl'].min()
             left = trans[(trans['wl'] <= wl0_guess) & (trans['T'] >= 0.1)]
             wl0 = np.interp(0.5, left['T'], left['wl'])
@@ -208,13 +208,13 @@ class Filter:
                 ax1.set_xlabel('Wavelength (nm)')
                 ax1.set_ylabel('Transmission')
 
-            dfreq = np.trapz(trans['T'].quantity, trans['freq'].quantity)
-            freq_eff = np.trapz(trans['T'].quantity * trans['freq'].quantity,
+            dfreq = np.trapezoid(trans['T'].quantity, trans['freq'].quantity)
+            freq_eff = np.trapezoid(trans['T'].quantity * trans['freq'].quantity,
                                 trans['freq'].quantity) / dfreq
             freq0 = np.interp(0.5, right['T'], right['freq'])
             freq1 = np.interp(0.5, left['T'], left['freq'])
             T_per_freq = trans['T'].quantity / trans['freq'].quantity
-            trans['T_norm_per_freq'] = (T_per_freq / np.trapz(T_per_freq, trans['freq'].quantity))
+            trans['T_norm_per_freq'] = (T_per_freq / np.trapezoid(T_per_freq, trans['freq'].quantity))
             if show:
                 plt.figure(2)
                 ax2 = plt.gca()
@@ -309,7 +309,7 @@ class Filter:
             Average spectral luminosity in the filter in watts per hertz
         """
         freq = self.trans['freq'].value * (1. + z)
-        return np.trapz(spectrum(freq, *args, **kwargs) * extinction_law(freq, ebv)
+        return np.trapezoid(spectrum(freq, *args, **kwargs) * extinction_law(freq, ebv)
                         * self.trans['T_norm_per_freq'].data, self.trans['freq'].data)
 
     def spectrum(self, freq, lum, z=0., ebv=0.):
@@ -339,8 +339,8 @@ class Filter:
         freq *= (1. + z)
         T_per_freq = self.trans['T'].value / self.trans['freq'].value
         T_interp = np.interp(freq, self.trans['freq'][::-1].value, T_per_freq[::-1], left=0., right=0.)
-        T_norm_per_freq = T_interp / np.trapz(T_interp, freq)
-        return np.trapz(lum * extinction_law(freq, ebv) * T_norm_per_freq, freq)
+        T_norm_per_freq = T_interp / np.trapezoid(T_interp, freq)
+        return np.trapezoid(lum * extinction_law(freq, ebv) * T_norm_per_freq, freq)
 
     def __str__(self):
         return self.name

--- a/lightcurve_fitting/speccal.py
+++ b/lightcurve_fitting/speccal.py
@@ -400,7 +400,7 @@ def calibrate_spectra(spectra, lc, filters=None, order=0, subtract_percentile=No
                 continue
             flux_lc = np.interp(mjd, lc_filt['MJD'], lc_filt['flux'])
             trans_interp = np.interp(nu, filt.trans['freq'], filt.trans['T_norm_per_freq'])
-            flux_spec = np.trapz(Fnu * trans_interp, nu) / np.trapz(trans_interp, nu)
+            flux_spec = np.trapezoid(Fnu * trans_interp, nu) / np.trapezoid(trans_interp, nu)
             ratio = flux_lc / flux_spec
             if show:
                 ax2.axvspan(freq0, freq1, color=filt.color, alpha=0.2)

--- a/lightcurve_fitting/speccal.py
+++ b/lightcurve_fitting/speccal.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
 import numpy as np
+try:
+    from numpy import trapezoid
+except ImportError:
+    from numpy import trapz as trapezoid
 from .lightcurve import LC
 from astropy import constants as const, units as u
 from astropy.io import fits, ascii
@@ -400,7 +404,7 @@ def calibrate_spectra(spectra, lc, filters=None, order=0, subtract_percentile=No
                 continue
             flux_lc = np.interp(mjd, lc_filt['MJD'], lc_filt['flux'])
             trans_interp = np.interp(nu, filt.trans['freq'], filt.trans['T_norm_per_freq'])
-            flux_spec = np.trapezoid(Fnu * trans_interp, nu) / np.trapezoid(trans_interp, nu)
+            flux_spec = trapezoid(Fnu * trans_interp, nu) / trapezoid(trans_interp, nu)
             ratio = flux_lc / flux_spec
             if show:
                 ax2.axvspan(freq0, freq1, color=filt.color, alpha=0.2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # List required packages in this file, one per line.
-numpy < 2  # extinction package does not work with numpy 2
+numpy 
 matplotlib
 emcee >= 3.1.1
 corner


### PR DESCRIPTION
The package as is uses `pkg_resources` from setuptools which was deprecated.
Also, the `versioneer.py` file uses the deprecated `SafeConfigParser`, which had to be updated to allow installation on a newer python version.
Lastly, `numpy` had changed `trapz` to `trapezoid`, so I did that change too.

I successfully installed the code after these changes in Python 3.14, but I could not find any tests in the package repository to test it on. I found one Jupyter notebook and edited it to run the code there, but I'm not sure if things changed because the original didn't have any output on it. 
Would you kindly point me at some such tests or otherwise help me get this PR checked? I want to use this package with newer Python versions, and while it currently runs for me, I might have unknowingly broken some other part of the code I did not use yet.

Many thanks! 🤘 