### PR TITLE
deprecate filter.char; use comma-separated full filter names

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,10 @@
 Release History
 ===============
 
+Unreleased
+----------
+* Deprecate :class:`.Filter.char`; bolometric output table now has comma-separated full filter names
+
 v0.11.0 (2026-09-07)
 --------------------
 If you were using :func:`.readfitsspec` or :func:`.readspec` directly,

--- a/lightcurve_fitting/bolometric.py
+++ b/lightcurve_fitting/bolometric.py
@@ -764,7 +764,7 @@ def calculate_bolometric(lc, z=0., outpath='.', res=1., nwalkers=10, burnin_step
             continue
 
         mjdavg, dmjd0, dmjd1 = median_and_unc(epoch1['MJD'], 100.)
-        filtstr = ''.join([f.char for f in sorted(filts)])
+        filtstr = ','.join([f.name for f in sorted(filts)])
 
         # blackbody - least squares
         T_range = (priors[0].p_min, priors[0].p_max)

--- a/lightcurve_fitting/filters.py
+++ b/lightcurve_fitting/filters.py
@@ -79,8 +79,6 @@ class Filter:
         The default name of the filter
     names : list
         A list of aliases for the filter
-    char : str
-        A single-character identifier for the filter
     color : str, tuple
         The color used when plotting photometry in this filter
     linecolor : str, tuple
@@ -129,14 +127,6 @@ class Filter:
         else:
             self.name = names
             self.names = [names]
-        if len(self.name) == 1:
-            self.char = self.name
-        else:
-            shortest = sorted(self.names, key=len)[0]
-            if len(shortest) == 1:
-                self.char = shortest
-            else:
-                self.char = 'x'
         self.color = color
         if linecolor:
             self.linecolor = linecolor

--- a/lightcurve_fitting/models.py
+++ b/lightcurve_fitting/models.py
@@ -786,8 +786,8 @@ class BaseCompanionShocking(Model):
             elif filt.name == 'DLT40':
                 sifto_filt = 'r'
                 scale_filt = filt
-            elif filt.char in sifto.colnames:
-                sifto_filt = filt.char
+            elif filt.name in sifto.colnames:
+                sifto_filt = filt.name
                 scale_filt = filt
             else:
                 raise Exception('No SiFTO template for filter ' + filt.name)
@@ -991,7 +991,7 @@ class CompanionShocking(BaseCompanionShocking):
 
         sifto_factors = {'r': rr, 'i': ri}
         kasen_factors = {'U': rU}
-        y_fit = np.array([L1 * kasen_factors.get(filt.char, 1.) + L2 * sifto_factors.get(filt.char, 1.)
+        y_fit = np.array([L1 * kasen_factors.get(filt.name, 1.) + L2 * sifto_factors.get(filt.name, 1.)
                           for L1, L2, filt in zip(Lnu_kasen, Lnu_sifto, f)])
 
         return y_fit


### PR DESCRIPTION
Resolves #10 by switching from `Filter.char` to `Filter.name` everywhere.